### PR TITLE
Rename nz-dbt to dbt-ibm-netezza for release

### DIFF
--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -43,7 +43,7 @@ jobs:
         runs-on: ubuntu-latest
         environment:
           name: pypi
-          url: https://pypi.org/dbt-ibm-netezza
+          url: https://pypi.org/p/dbt-ibm-netezza
         permissions:
           id-token: write
 

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -43,7 +43,7 @@ jobs:
         runs-on: ubuntu-latest
         environment:
           name: pypi
-          url: https://pypi.org/p/nz-dbt
+          url: https://pypi.org/dbt-ibm-netezza
         permissions:
           id-token: write
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nz-dbt
 
-The `nz-dbt` package contains all of the code required to make `dbt` operate on a Netezza database. For more information on using dbt, consult [their docs](https://docs.getdbt.com/docs).
+The `dbt-ibm-netezza` package contains all of the code required to make `dbt` operate on a Netezza database. For more information on using dbt, consult [their docs](https://docs.getdbt.com/docs).
 
 
 ### Performance Optimizations
@@ -52,7 +52,7 @@ To install all the dependencies for the tool, follow these steps:
     cd nz-dbt
     ```
 
-2. Install `nz-dbt` using the command `pip install .`
+2. Install `dbt-ibm-netezza` using the command `pip install .`
 
 Initialize a new dbt project using command `dbt init` and provide all the informantion prompted like project_name, hostname, database, etc. The details you put are case-sensitive.
 

--- a/dbt/include/netezza/macros/adapters.sql
+++ b/dbt/include/netezza/macros/adapters.sql
@@ -86,7 +86,7 @@
 
 {% macro netezza__drop_schema(relation) -%}
   {%- call statement('drop_schema') -%}
-    {{ exceptions.raise_compiler_error("nz-dbt does not support drop_schema") }}
+    {{ exceptions.raise_compiler_error("dbt-ibm-netezza does not support drop_schema") }}
   {% endcall %}
 {% endmacro %}
 

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ def _get_dbt_core_version():
     return f"{minor}{pre}"
 
 
-package_name = "nz-dbt"
-package_version = "1.0.1"
+package_name = "dbt-ibm-netezza"
+package_version = "1.0.2"
 dbt_core_version = _get_dbt_core_version()
 description = """The Netezza adapter plugin for dbt"""
 

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -121,7 +121,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support connection timeout yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support connection timeout yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_changed_connect_timeout(self, nzpy):
@@ -156,7 +156,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support keepalives_idle yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support keepalives_idle yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_changed_keepalive(self, nzpy):
@@ -192,7 +192,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support application rename yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support application rename yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_changed_application_name(self, nzpy):
@@ -212,7 +212,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support role in connections yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support role in connections yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_role(self, nzpy):
@@ -245,7 +245,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support sslmode yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support sslmode yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_sslmode(self, nzpy):
@@ -266,7 +266,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support sslmode yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support sslmode yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_ssl_parameters(self, nzpy):
@@ -293,7 +293,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support search_path yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support search_path yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_schema_with_space(self, nzpy):
@@ -314,7 +314,7 @@ class TestNetezzaAdapter(TestCase):
         )
 
     @pytest.mark.skip(
-        """Skipping. since nz-dbt doesn't support keepalives_idle yet."""
+        """Skipping. since dbt-ibm-netezza doesn't support keepalives_idle yet."""
     )
     @mock.patch("dbt.adapters.netezza.connections.nzpy")
     def test_set_zero_keepalive(self, nzpy):


### PR DESCRIPTION
To add IBM Netezza's dbt adapter to the list of trusted adapters, it is required to rename the pypi package according to the convention.