### PR TITLE
Update the dbt init command to automatically materialize the et_options.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Create the tables into your db using the info in the `datainsertion.sql` file.
 
 We can load the data into our tables using the `dbt seed command` , it would insert the data from all the seed files into tables created with the name of the seed files.
 
-Before using the `dbt seed` command, ensure that you have provided an `et_options.yml` file in your dbt project folder. This file is crucial for configuring the parameters for inserting data from an external file into your table.
+The `et_options.yml` file created after the initialization of a dbt project, is crucial for configuring the parameters for inserting data from an external file into your table.
 
 > **Note:** 
 > 

--- a/dbt/__init__.py
+++ b/dbt/__init__.py
@@ -1,1 +1,56 @@
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+
+import click
+
+from pathlib import Path
+from dbt.cli import params as p
+from dbt.cli import requires
+from dbt.cli.main import cli, global_flags
+from dbt.task.init import InitTask
+from dbt.events.types import SettingUpProfile, InvalidProfileTemplateYAML
+from dbt_common.events.functions import fire_event
+from dbt.adapters.netezza.et_options_parser import create_et_options
+
+class NetezzaInitTask(InitTask):
+    def setup_profile(self, profile_name: str) -> None:
+        """Set up a new profile for a project"""
+        fire_event(SettingUpProfile())
+        if not self.check_if_can_write_profile(profile_name=profile_name):
+            return
+        # If a profile_template.yml exists in the project root, that effectively
+        # overrides the profile_template.yml for the given target.
+        profile_template_path = Path("profile_template.yml")
+        if profile_template_path.exists():
+            try:
+                # This relies on a valid profile_template.yml from the user,
+                # so use a try: except to fall back to the default on failure
+                self.create_profile_using_project_profile_template(profile_name)
+                return
+            except Exception:
+                fire_event(InvalidProfileTemplateYAML())
+        adapter = self.ask_for_adapter_choice()
+        if adapter == 'netezza':
+            create_et_options('.')
+        self.create_profile_from_target(adapter, profile_name=profile_name)
+
+# dbt init
+@cli.command("init")
+@click.pass_context
+@global_flags
+# for backwards compatibility, accept 'project_name' as an optional positional argument
+@click.argument("project_name", required=False)
+@p.profiles_dir_exists_false
+@p.project_dir
+@p.skip_profile_setup
+@p.vars
+@requires.postflight
+@requires.preflight
+def netezza_init(ctx, **kwargs):
+    """Initialize a new dbt project for netezza driver."""
+
+    with NetezzaInitTask(ctx.obj["flags"]) as task:
+        results = task.run()
+        success = task.interpret_results(results)
+    return results, success
+
+init = netezza_init

--- a/dbt/adapters/netezza/et_options_parser.py
+++ b/dbt/adapters/netezza/et_options_parser.py
@@ -1,12 +1,12 @@
 import os
 import yaml
 from typing import Dict
-  
+
 class ETOptions:
     def __init__(self, options: Dict):
         self.options = options
-        
-           
+
+
 def et_options_constructor(loader, node):
     """
     Returns a dict of values written in et_options.yaml file
@@ -27,8 +27,8 @@ def parse_et_options_yaml(file_path):
     with open(file_path, 'r') as file:
         data = yaml.safe_load(file)
     return data
-    
-def get_et_options_as_string(user_file_path: str):    
+
+def get_et_options_as_string(user_file_path: str):
     yaml.SafeLoader.add_constructor('!ETOptions', et_options_constructor)
     et_options_data = parse_et_options_yaml(user_file_path)
     if not et_options_data:
@@ -37,4 +37,9 @@ def get_et_options_as_string(user_file_path: str):
     for k,v in et_options_data[0].options.items():
         to_be_returned += f"{k} {v}\n"
     return to_be_returned
-    
+
+def create_et_options(project_path):
+    yaml.add_representer(ETOptions, etoptions_representer)
+    et_options = ETOptions(options={'SkipRows': '1', 'Delimiter': "','", 'DateDelim': "'-'", 'MaxErrors': '0'})
+    with open(f"{project_path}/et_options.yml", "w") as file:
+        yaml.dump([et_options], file, default_flow_style=False)

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -1,8 +1,9 @@
-from contextlib import contextmanager
-from io import StringIO
-from os import chdir
+import yaml
 import os
+from os import chdir
 from os.path import normcase, normpath
+from io import StringIO
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
@@ -13,9 +14,8 @@ from dbt_common.events.functions import (
     stop_capture_stdout_logs,
 )
 from dbt_common.events.base_types import EventMsg
-import yaml
 
-from dbt.adapters.netezza.et_options_parser import ETOptions, etoptions_representer
+from dbt.adapters.netezza.et_options_parser import create_et_options
 
 
 @contextmanager
@@ -41,13 +41,6 @@ def normalize(path):
     return normcase(normpath(path))
 
 
-def create_et_options(project_path):
-    yaml.add_representer(ETOptions, etoptions_representer)
-    et_options = ETOptions(options={'SkipRows': '1', 'Delimiter': "','", 'DateDelim': "'-'", 'MaxErrors': '0'})
-    with open(f"{project_path}/et_options.yml", "w") as file:
-        yaml.dump([et_options], file, default_flow_style=False)
-
-
 def update_seed_file_names(seeds_path: str):
     if os.path.exists(seeds_path):
         for i in os.listdir(seeds_path):
@@ -59,8 +52,8 @@ def update_seed_file_names(seeds_path: str):
 
 
 def run_dbt(
-    args: Optional[List[str]] = None, 
-    expect_pass: bool = True, 
+    args: Optional[List[str]] = None,
+    expect_pass: bool = True,
     callbacks: Optional[List[Callable[[EventMsg], None]]] = None
 ):
     print("run_dbt invoked for functional tests...")
@@ -70,7 +63,7 @@ def run_dbt(
 
     from dbt.flags import get_flags
     flags = get_flags()
-    
+
     project_dir = getattr(flags, "PROJECT_DIR", None)
     profiles_dir = getattr(flags, "PROFILES_DIR", None)
 


### PR DESCRIPTION
Problem:
Initially we had to manually set up the et_options.yml file needed to provide the parameters for insertion using external tables in netezza, after initializing the project.

Solution:
On using the `dbt init` command, and after providing the driver as netezza, the et_options.yml file is materialized in the project directory.

Testing:
Run the `dbt init` command and complete the setup using the netezza adapter. We would see the et_options.yml file in the main project directory.