### PR TITLE
DBT snapshot fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-ibm-netezza"
-package_version = "1.0.3"
+package_version = "1.0.4"
 dbt_core_version = _get_dbt_core_version()
 description = """The Netezza adapter plugin for dbt"""
 


### PR DESCRIPTION
Problem:
The dbt snapshot command was not working as expected

Solution:
Updated the code o support snapshot and also updated the version for dbt

Testing:
```
(venv) [my-system]# dbt snapshot
15:54:07  Running with dbt=1.9.2
15:54:07  Registered adapter: netezza=1.5.0
15:54:08  Found 2 models, 4 data tests, 1 snapshot, 422 macros
15:54:08  
15:54:08  Concurrency: 3 threads (target='dev')
15:54:08  
15:54:10  1 of 1 START snapshot ADMIN.test_ss ............................................ [RUN]
15:54:12  1 of 1 OK snapshotted ADMIN.test_ss ............................................ [OK in 2.76s]
15:54:12  
15:54:12  Finished running 1 snapshot in 0 hours 0 minutes and 4.61 seconds (4.61s).
15:54:12  
15:54:12  Completed successfully
15:54:12  
15:54:12  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```