### PR TITLE
Fix for dbt source freshness command

### DIFF
--- a/dbt/adapters/netezza/impl.py
+++ b/dbt/adapters/netezza/impl.py
@@ -23,6 +23,7 @@ from dbt.contracts.graph.manifest import Manifest
 from dbt_common.exceptions import CompilationError, DbtDatabaseError, MacroResultError
 from dbt_common.utils import filter_null_values, AttrDict
 from dbt.contracts.graph.nodes import ConstraintType
+from dbt.adapters.contracts.macros import MacroResolverProtocol
 
 @dataclass
 class NetezzaConfig(AdapterConfig):
@@ -245,7 +246,7 @@ class NetezzaAdapter(SQLAdapter):
         source: BaseRelation,
         loaded_at_field: str,
         filter: Optional[str],
-        manifest: Optional[Manifest] = None,
+        macro_resolver: Optional[MacroResolverProtocol] = None,
     ) -> Tuple[Optional[AdapterResponse], Dict[str, Any]]:
         """Calculate the freshness of sources in dbt, and return it"""
         kwargs: Dict[str, Any] = {
@@ -260,7 +261,7 @@ class NetezzaAdapter(SQLAdapter):
             AttrDict,  # current: contains AdapterResponse + agate.Table
             agate.Table,  # previous: just table
         ]
-        result = self.execute_macro(FRESHNESS_MACRO_NAME, kwargs=kwargs, manifest=manifest)
+        result = self.execute_macro(FRESHNESS_MACRO_NAME, kwargs=kwargs, macro_resolver=macro_resolver)
         if isinstance(result, agate.Table):
             deprecations.warn("collect-freshness-return-signature")
             adapter_response = None

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     url="https://github.com/IBM/nz-dbt",
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
-    install_requires=["dbt-core==1.9.2", "nzpy==1.15"],
+    install_requires=["dbt-core==1.9.2", "nzpy==1.17.1"],
     zip_safe=False,
     classifiers=[
         "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Problem :
The variable in the calculate freshness needs to be updated.

Solution:
Updated the variables as required

Testing:

Before
```
dbt source freshness
10:58:39  Running with dbt=1.9.2
10:58:40  Registered adapter: netezza=1.5.0
10:58:40  Found 1 seed, 8 models, 3 sources, 422 macros
10:58:40  
10:58:40  Concurrency: 3 threads (target='dev')
10:58:40  
10:58:40  1 of 1 START freshness of airbnb.reviews ....................................... [RUN]
10:58:41  Unhandled error while executing 
NetezzaAdapter.calculate_freshness() got an unexpected keyword argument 'macro_resolver'
10:58:41  1 of 1 ERROR freshness of airbnb.reviews ....................................... [ERROR in 0.12s]
10:58:41  
10:58:41  Finished running 1 source in 0 hours 0 minutes and 0.60 seconds (0.60s).
10:58:41  
10:58:41    NetezzaAdapter.calculate_freshness() got an unexpected keyword argument 'macro_resolver'
10:58:41  Done.
```

After
```
 dbt source freshness
10:59:46  Running with dbt=1.9.2
10:59:46  Registered adapter: netezza=1.5.0
10:59:47  Found 1 seed, 8 models, 3 sources, 422 macros
10:59:47  
10:59:47  Concurrency: 3 threads (target='dev')
10:59:47  
10:59:47  1 of 1 START freshness of airbnb.reviews ....................................... [RUN]
10:59:48  1 of 1 WARN freshness of airbnb.reviews ........................................ [WARN in 0.38s]
10:59:48  
10:59:48  Finished running 1 source in 0 hours 0 minutes and 1.06 seconds (1.06s).
10:59:48  Done.
```